### PR TITLE
feat: upgrade goawx & support for job_slice_count

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     ],
     "shutdownAction": "stopCompose",
     "postCreateCommand": "chmod -R 700 .git",
-    "workspaceFolder": "/go/src/github.com/denouche/terraform-provider-awx",
+    "workspaceFolder": "/go/src/github.com/veepee-oss/terraform-provider-awx",
     // "overrideCommand": "",
     "extensions": [
         // General backend

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   vscode:
     build: .
     volumes:
-      - ../:/go/src/github.com/denouche/terraform-provider-awx
+      - ../:/go/src/github.com/veepee-oss/terraform-provider-awx
       # (only for debug)
-      #- ../../goawx:/go/src/github.com/denouche/goawx
+      #- ../../goawx:/go/src/github.com/veepee-oss/goawx
       - ~/.ssh:/home/vscode/.ssh:ro
       - ~/.ssh:/root/.ssh:ro
       - /var/run/docker.sock:/var/run/docker.sock

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=github.com
-NAMESPACE=denouche
+NAMESPACE=veepee-oss
 NAME=awx
 BINARY=terraform-provider-${NAME}
 VERSION=0.1

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Copy the provider to user's `~/.terraform.d` folder.
 > Important: if building the provider in an operating system other than Linux x86_64, adjust the paths below replacing `linux_amd64` with the corresponding platform code. E.g.: `darwin_amd64` for macOS.
 
 ```sh
-mkdir -p ~/.terraform.d/plugins/github.com/denouche/awx/0.1/linux_amd64/terraform-provider-awx
-find ./dist/terraform-provider-awx_linux_amd64/* -name 'terraform-provider-awx*' -print0 | xargs -0 -I {} mv {} ~/.terraform.d/plugins/github.com/denouche/awx/0.1/linux_amd64/terraform-provider-awx
+mkdir -p ~/.terraform.d/plugins/github.com/veepee-oss/awx/0.1/linux_amd64/terraform-provider-awx
+find ./dist/terraform-provider-awx_linux_amd64/* -name 'terraform-provider-awx*' -print0 | xargs -0 -I {} mv {} ~/.terraform.d/plugins/github.com/veepee-oss/awx/0.1/linux_amd64/terraform-provider-awx
 ```
 
 ### 4) Run tests and ensure they're all passing
@@ -41,8 +41,8 @@ go test ./test -count=1
 For convenience, all the steps above can be achieved by a single command that combines all of them:
 ```sh
 goreleaser build --snapshot --rm-dist \
-    && mkdir -p ~/.terraform.d/plugins/github.com/denouche/awx/0.1/linux_amd64/ \
-    && find ./dist/terraform-provider-awx_linux_amd64/* -name 'terraform-provider-awx*' -print0 | xargs -0 -I {} mv {} ~/.terraform.d/plugins/github.com/denouche/awx/0.1/linux_amd64/terraform-provider-awx \
+    && mkdir -p ~/.terraform.d/plugins/github.com/veepee-oss/awx/0.1/linux_amd64/ \
+    && find ./dist/terraform-provider-awx_linux_amd64/* -name 'terraform-provider-awx*' -print0 | xargs -0 -I {} mv {} ~/.terraform.d/plugins/github.com/veepee-oss/awx/0.1/linux_amd64/terraform-provider-awx \
     && go test ./test -count=1
 ```
 

--- a/awx/data_source_credential.go
+++ b/awx/data_source_credential.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_credential_azure_key_vault.go
+++ b/awx/data_source_credential_azure_key_vault.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_credential_type.go
+++ b/awx/data_source_credential_type.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_credentials.go
+++ b/awx/data_source_credentials.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_execution_environment.go
+++ b/awx/data_source_execution_environment.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_inventory.go
+++ b/awx/data_source_inventory.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_inventory_group.go
+++ b/awx/data_source_inventory_group.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_inventory_role.go
+++ b/awx/data_source_inventory_role.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_job_template.go
+++ b/awx/data_source_job_template.go
@@ -18,7 +18,7 @@ import (
 
 	"log"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_notification_template.go
+++ b/awx/data_source_notification_template.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_organization.go
+++ b/awx/data_source_organization.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_organization_role.go
+++ b/awx/data_source_organization_role.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_organizations.go
+++ b/awx/data_source_organizations.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_project.go
+++ b/awx/data_source_project.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_project_role.go
+++ b/awx/data_source_project_role.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_schedule.go
+++ b/awx/data_source_schedule.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_team.go
+++ b/awx/data_source_team.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/data_source_workflow_job_template.go
+++ b/awx/data_source_workflow_job_template.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/helpers.go
+++ b/awx/helpers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"gopkg.in/yaml.v2"

--- a/awx/provider.go
+++ b/awx/provider.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential.go
+++ b/awx/resource_credential.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_azure_key_vault.go
+++ b/awx/resource_credential_azure_key_vault.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_galaxy.go
+++ b/awx/resource_credential_galaxy.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_gitlab.go
+++ b/awx/resource_credential_gitlab.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_google_compute_engine.go
+++ b/awx/resource_credential_google_compute_engine.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_input_source.go
+++ b/awx/resource_credential_input_source.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_machine.go
+++ b/awx/resource_credential_machine.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_scm.go
+++ b/awx/resource_credential_scm.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_credential_type.go
+++ b/awx/resource_credential_type.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_execution_environment.go
+++ b/awx/resource_execution_environment.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_host.go
+++ b/awx/resource_host.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_instance_group.go
+++ b/awx/resource_instance_group.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_inventory.go
+++ b/awx/resource_inventory.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_inventory_group.go
+++ b/awx/resource_inventory_group.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_inventory_source.go
+++ b/awx/resource_inventory_source.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_job_template.go
+++ b/awx/resource_job_template.go
@@ -28,7 +28,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -73,6 +73,11 @@ func resourceJobTemplate() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  0,
+			},
+			"job_slice_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
 			},
 			"limit": {
 				Type:     schema.TypeString,
@@ -132,6 +137,11 @@ func resourceJobTemplate() *schema.Resource {
 				Default:  false,
 			},
 			"ask_limit_on_launch": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"ask_job_slice_count_on_launch": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -211,38 +221,40 @@ func resourceJobTemplateCreate(ctx context.Context, d *schema.ResourceData, m in
 	awxService := client.JobTemplateService
 
 	result, err := awxService.CreateJobTemplate(map[string]interface{}{
-		"name":                     d.Get("name").(string),
-		"description":              d.Get("description").(string),
-		"job_type":                 d.Get("job_type").(string),
-		"inventory":                AtoipOr(d.Get("inventory_id").(string), nil),
-		"project":                  d.Get("project_id").(int),
-		"playbook":                 d.Get("playbook").(string),
-		"forks":                    d.Get("forks").(int),
-		"limit":                    d.Get("limit").(string),
-		"verbosity":                d.Get("verbosity").(int),
-		"extra_vars":               d.Get("extra_vars").(string),
-		"job_tags":                 d.Get("job_tags").(string),
-		"force_handlers":           d.Get("force_handlers").(bool),
-		"skip_tags":                d.Get("skip_tags").(string),
-		"start_at_task":            d.Get("start_at_task").(string),
-		"timeout":                  d.Get("timeout").(int),
-		"use_fact_cache":           d.Get("use_fact_cache").(bool),
-		"host_config_key":          d.Get("host_config_key").(string),
-		"ask_diff_mode_on_launch":  d.Get("ask_diff_mode_on_launch").(bool),
-		"ask_variables_on_launch":  d.Get("ask_variables_on_launch").(bool),
-		"ask_limit_on_launch":      d.Get("ask_limit_on_launch").(bool),
-		"ask_tags_on_launch":       d.Get("ask_tags_on_launch").(bool),
-		"ask_skip_tags_on_launch":  d.Get("ask_skip_tags_on_launch").(bool),
-		"ask_job_type_on_launch":   d.Get("ask_job_type_on_launch").(bool),
-		"ask_verbosity_on_launch":  d.Get("ask_verbosity_on_launch").(bool),
-		"ask_inventory_on_launch":  d.Get("ask_inventory_on_launch").(bool),
-		"ask_credential_on_launch": d.Get("ask_credential_on_launch").(bool),
-		"survey_enabled":           d.Get("survey_enabled").(bool),
-		"become_enabled":           d.Get("become_enabled").(bool),
-		"diff_mode":                d.Get("diff_mode").(bool),
-		"allow_simultaneous":       d.Get("allow_simultaneous").(bool),
-		"custom_virtualenv":        AtoipOr(d.Get("custom_virtualenv").(string), nil),
-		"execution_environment":    AtoipOr(d.Get("execution_environment").(string), nil),
+		"name":                          d.Get("name").(string),
+		"description":                   d.Get("description").(string),
+		"job_type":                      d.Get("job_type").(string),
+		"inventory":                     AtoipOr(d.Get("inventory_id").(string), nil),
+		"project":                       d.Get("project_id").(int),
+		"playbook":                      d.Get("playbook").(string),
+		"forks":                         d.Get("forks").(int),
+		"job_slice_count":               d.Get("job_slice_count").(int),
+		"limit":                         d.Get("limit").(string),
+		"verbosity":                     d.Get("verbosity").(int),
+		"extra_vars":                    d.Get("extra_vars").(string),
+		"job_tags":                      d.Get("job_tags").(string),
+		"force_handlers":                d.Get("force_handlers").(bool),
+		"skip_tags":                     d.Get("skip_tags").(string),
+		"start_at_task":                 d.Get("start_at_task").(string),
+		"timeout":                       d.Get("timeout").(int),
+		"use_fact_cache":                d.Get("use_fact_cache").(bool),
+		"host_config_key":               d.Get("host_config_key").(string),
+		"ask_diff_mode_on_launch":       d.Get("ask_diff_mode_on_launch").(bool),
+		"ask_variables_on_launch":       d.Get("ask_variables_on_launch").(bool),
+		"ask_limit_on_launch":           d.Get("ask_limit_on_launch").(bool),
+		"ask_job_slice_count_on_launch": d.Get("ask_limit_on_launch").(bool),
+		"ask_tags_on_launch":            d.Get("ask_tags_on_launch").(bool),
+		"ask_skip_tags_on_launch":       d.Get("ask_skip_tags_on_launch").(bool),
+		"ask_job_type_on_launch":        d.Get("ask_job_type_on_launch").(bool),
+		"ask_verbosity_on_launch":       d.Get("ask_verbosity_on_launch").(bool),
+		"ask_inventory_on_launch":       d.Get("ask_inventory_on_launch").(bool),
+		"ask_credential_on_launch":      d.Get("ask_credential_on_launch").(bool),
+		"survey_enabled":                d.Get("survey_enabled").(bool),
+		"become_enabled":                d.Get("become_enabled").(bool),
+		"diff_mode":                     d.Get("diff_mode").(bool),
+		"allow_simultaneous":            d.Get("allow_simultaneous").(bool),
+		"custom_virtualenv":             AtoipOr(d.Get("custom_virtualenv").(string), nil),
+		"execution_environment":         AtoipOr(d.Get("execution_environment").(string), nil),
 	}, map[string]string{})
 	if err != nil {
 		log.Printf("Fail to Create Template %v", err)
@@ -274,38 +286,40 @@ func resourceJobTemplateUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	_, err = awxService.UpdateJobTemplate(id, map[string]interface{}{
-		"name":                     d.Get("name").(string),
-		"description":              d.Get("description").(string),
-		"job_type":                 d.Get("job_type").(string),
-		"inventory":                AtoipOr(d.Get("inventory_id").(string), nil),
-		"project":                  d.Get("project_id").(int),
-		"playbook":                 d.Get("playbook").(string),
-		"forks":                    d.Get("forks").(int),
-		"limit":                    d.Get("limit").(string),
-		"verbosity":                d.Get("verbosity").(int),
-		"extra_vars":               d.Get("extra_vars").(string),
-		"job_tags":                 d.Get("job_tags").(string),
-		"force_handlers":           d.Get("force_handlers").(bool),
-		"skip_tags":                d.Get("skip_tags").(string),
-		"start_at_task":            d.Get("start_at_task").(string),
-		"timeout":                  d.Get("timeout").(int),
-		"use_fact_cache":           d.Get("use_fact_cache").(bool),
-		"host_config_key":          d.Get("host_config_key").(string),
-		"ask_diff_mode_on_launch":  d.Get("ask_diff_mode_on_launch").(bool),
-		"ask_variables_on_launch":  d.Get("ask_variables_on_launch").(bool),
-		"ask_limit_on_launch":      d.Get("ask_limit_on_launch").(bool),
-		"ask_tags_on_launch":       d.Get("ask_tags_on_launch").(bool),
-		"ask_skip_tags_on_launch":  d.Get("ask_skip_tags_on_launch").(bool),
-		"ask_job_type_on_launch":   d.Get("ask_job_type_on_launch").(bool),
-		"ask_verbosity_on_launch":  d.Get("ask_verbosity_on_launch").(bool),
-		"ask_inventory_on_launch":  d.Get("ask_inventory_on_launch").(bool),
-		"ask_credential_on_launch": d.Get("ask_credential_on_launch").(bool),
-		"survey_enabled":           d.Get("survey_enabled").(bool),
-		"become_enabled":           d.Get("become_enabled").(bool),
-		"diff_mode":                d.Get("diff_mode").(bool),
-		"allow_simultaneous":       d.Get("allow_simultaneous").(bool),
-		"custom_virtualenv":        AtoipOr(d.Get("custom_virtualenv").(string), nil),
-		"execution_environment":    AtoipOr(d.Get("execution_environment").(string), nil),
+		"name":                          d.Get("name").(string),
+		"description":                   d.Get("description").(string),
+		"job_type":                      d.Get("job_type").(string),
+		"inventory":                     AtoipOr(d.Get("inventory_id").(string), nil),
+		"project":                       d.Get("project_id").(int),
+		"playbook":                      d.Get("playbook").(string),
+		"forks":                         d.Get("forks").(int),
+		"job_slice_count":               d.Get("job_slice_count").(int),
+		"limit":                         d.Get("limit").(string),
+		"verbosity":                     d.Get("verbosity").(int),
+		"extra_vars":                    d.Get("extra_vars").(string),
+		"job_tags":                      d.Get("job_tags").(string),
+		"force_handlers":                d.Get("force_handlers").(bool),
+		"skip_tags":                     d.Get("skip_tags").(string),
+		"start_at_task":                 d.Get("start_at_task").(string),
+		"timeout":                       d.Get("timeout").(int),
+		"use_fact_cache":                d.Get("use_fact_cache").(bool),
+		"host_config_key":               d.Get("host_config_key").(string),
+		"ask_diff_mode_on_launch":       d.Get("ask_diff_mode_on_launch").(bool),
+		"ask_variables_on_launch":       d.Get("ask_variables_on_launch").(bool),
+		"ask_limit_on_launch":           d.Get("ask_limit_on_launch").(bool),
+		"ask_job_slice_count_on_launch": d.Get("ask_limit_on_launch").(bool),
+		"ask_tags_on_launch":            d.Get("ask_tags_on_launch").(bool),
+		"ask_skip_tags_on_launch":       d.Get("ask_skip_tags_on_launch").(bool),
+		"ask_job_type_on_launch":        d.Get("ask_job_type_on_launch").(bool),
+		"ask_verbosity_on_launch":       d.Get("ask_verbosity_on_launch").(bool),
+		"ask_inventory_on_launch":       d.Get("ask_inventory_on_launch").(bool),
+		"ask_credential_on_launch":      d.Get("ask_credential_on_launch").(bool),
+		"survey_enabled":                d.Get("survey_enabled").(bool),
+		"become_enabled":                d.Get("become_enabled").(bool),
+		"diff_mode":                     d.Get("diff_mode").(bool),
+		"allow_simultaneous":            d.Get("allow_simultaneous").(bool),
+		"custom_virtualenv":             AtoipOr(d.Get("custom_virtualenv").(string), nil),
+		"execution_environment":         AtoipOr(d.Get("execution_environment").(string), nil),
 	}, map[string]string{})
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -342,6 +356,7 @@ func setJobTemplateResourceData(d *schema.ResourceData, r *awx.JobTemplate) *sch
 	d.Set("ask_credential_on_launch", r.AskCredentialOnLaunch)
 	d.Set("ask_job_type_on_launch", r.AskJobTypeOnLaunch)
 	d.Set("ask_limit_on_launch", r.AskLimitOnLaunch)
+	d.Set("ask_job_slice_count_on_launch", r.AskJobSliceCountOnLaunch)
 	d.Set("ask_skip_tags_on_launch", r.AskSkipTagsOnLaunch)
 	d.Set("ask_tags_on_launch", r.AskTagsOnLaunch)
 	d.Set("ask_variables_on_launch", r.AskVariablesOnLaunch)
@@ -349,6 +364,7 @@ func setJobTemplateResourceData(d *schema.ResourceData, r *awx.JobTemplate) *sch
 	d.Set("extra_vars", normalizeJsonYaml(r.ExtraVars))
 	d.Set("force_handlers", r.ForceHandlers)
 	d.Set("forks", r.Forks)
+	d.Set("job_slice_count", r.JobSliceCount)
 	d.Set("host_config_key", r.HostConfigKey)
 	d.Set("inventory_id", r.Inventory)
 	d.Set("job_tags", r.JobTags)

--- a/awx/resource_job_template_credential.go
+++ b/awx/resource_job_template_credential.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_job_template_launch.go
+++ b/awx/resource_job_template_launch.go
@@ -33,7 +33,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_job_template_notification_template_shared.go
+++ b/awx/resource_job_template_notification_template_shared.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_notification_template.go
+++ b/awx/resource_notification_template.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_organization.go
+++ b/awx/resource_organization.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_organization_galaxy_credential.go
+++ b/awx/resource_organization_galaxy_credential.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_project.go
+++ b/awx/resource_project.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_schedule.go
+++ b/awx/resource_schedule.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_setting.go
+++ b/awx/resource_setting.go
@@ -47,7 +47,7 @@ import (
 	"encoding/json"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_settings_ldap_team_map.go
+++ b/awx/resource_settings_ldap_team_map.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_team.go
+++ b/awx/resource_team.go
@@ -48,7 +48,7 @@ import (
 	"strconv"
 	"time"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_user.go
+++ b/awx/resource_user.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template.go
+++ b/awx/resource_workflow_job_template.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_node.go
+++ b/awx/resource_workflow_job_template_node.go
@@ -23,7 +23,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_node_always.go
+++ b/awx/resource_workflow_job_template_node_always.go
@@ -21,7 +21,7 @@ package awx
 import (
 	"context"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_node_failure.go
+++ b/awx/resource_workflow_job_template_node_failure.go
@@ -21,7 +21,7 @@ package awx
 import (
     "context"
 
-    awx "github.com/denouche/goawx/client"
+    awx "github.com/veepee-oss/goawx/client"
     "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_node_shared.go
+++ b/awx/resource_workflow_job_template_node_shared.go
@@ -6,7 +6,7 @@ import (
     "log"
     "strconv"
 
-    awx "github.com/denouche/goawx/client"
+    awx "github.com/veepee-oss/goawx/client"
     "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_node_success.go
+++ b/awx/resource_workflow_job_template_node_success.go
@@ -21,7 +21,7 @@ package awx
 import (
     "context"
 
-    awx "github.com/denouche/goawx/client"
+    awx "github.com/veepee-oss/goawx/client"
     "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_notification_template_shared.go
+++ b/awx/resource_workflow_job_template_notification_template_shared.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/awx/resource_workflow_job_template_schedule.go
+++ b/awx/resource_workflow_job_template_schedule.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"strconv"
 
-	awx "github.com/denouche/goawx/client"
+	awx "github.com/veepee-oss/goawx/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/examples/awx/main.tf
+++ b/examples/awx/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     awx = {
-      source = "github.com/denouche/awx"
+      source = "veepee-oss/awx"
       version = "0.1"
     }
   }

--- a/examples/k8s/base/versions.tf
+++ b/examples/k8s/base/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     awx = {
-      source  = "github.com/denouche/awx"
+      source  = "veepee-oss/awx"
       version = "0.1"
     }
   }

--- a/examples/k8s/data/versions.tf
+++ b/examples/k8s/data/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     awx = {
-      source  = "github.com/denouche/awx"
+      source  = "veepee-oss/awx"
       version = "0.1"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/denouche/terraform-provider-awx
+module github.com/veepee-oss/terraform-provider-awx
 
 go 1.14
 
 require (
-	github.com/roondar/goawx v1.1.1
 	github.com/gruntwork-io/terratest v0.31.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/stretchr/testify v1.7.0
+	github.com/veepee-oss/goawx v1.2.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,6 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denouche/goawx v0.17.0 h1:mtCfsYdKBSTO/3BGFPU7q13shAneLSlaJYEmqgLVwC0=
-github.com/denouche/goawx v0.17.0/go.mod h1:MppzSteoj2xgfiqiRWW/Bf1a8z2FrRyvah1z0J2vJTY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -511,6 +509,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238/go.mod h1:JwQJCMWpUDqjZrB5jpw0f5VbN7U95zxFy1ZDpoEarGo=
+github.com/veepee-oss/goawx v1.2.1 h1:z1tnv+fzAbbVVKcMck8wzfTmK4ymOc2NaQHZEIBRALI=
+github.com/veepee-oss/goawx v1.2.1/go.mod h1:mhF0JKKER1k/l93cQxFFTbIe9Qs0oBdzg1diOxyaJes=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/denouche/terraform-provider-awx/awx"
+	"github.com/veepee-oss/terraform-provider-awx/awx"
 )
 
 func main() {

--- a/tools/docs.go
+++ b/tools/docs.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/denouche/terraform-provider-awx/awx"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/veepee-oss/terraform-provider-awx/awx"
 )
 
 const (

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,12 +1,12 @@
-module github.com/denouche/terraform-provider-awx/tools
+module github.com/veepee-oss/terraform-provider-awx/tools
 
 go 1.14
 
 require (
-	github.com/denouche/terraform-provider-awx v0.1.2
+	github.com/veepee-oss/terraform-provider-awx v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/magefile/mage v1.11.0
 	github.com/nolte/plumbing v0.0.1
 )
 
-replace github.com/denouche/terraform-provider-awx => ../.
+replace github.com/veepee-oss/terraform-provider-awx => ../.

--- a/tools/magefile.go
+++ b/tools/magefile.go
@@ -10,7 +10,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
-	tools "github.com/denouche/terraform-provider-awx/tools"
+	tools "github.com/veepee-oss/terraform-provider-awx/tools"
 
 	// mage:import
 	"github.com/nolte/plumbing/cmd/kind"


### PR DESCRIPTION
Upgrade `goawx` in order to get the `job_slice_count` support.
Rename module & dependencies to `veepee-oss` instead of `denouche` .
Add support to `job_slice_count` in `job_template` resource.