### PR TITLE
Allow to define credential type for galaxy credentials

### DIFF
--- a/awx/resource_credential_galaxy.go
+++ b/awx/resource_credential_galaxy.go
@@ -42,7 +42,7 @@ func resourceCredentialGalaxy() *schema.Resource {
 			"credential_type_id": {
 				Type:     schema.TypeInt,
 				Default: 18,
-				Required: true,
+				Optional: true,
 			},
 			"url": {
 				Type:     schema.TypeString,

--- a/awx/resource_credential_galaxy.go
+++ b/awx/resource_credential_galaxy.go
@@ -39,6 +39,11 @@ func resourceCredentialGalaxy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"credential_type_id": {
+				Type:     schema.TypeInt,
+				Default: 18,
+				Required: true,
+			},
 			"url": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -64,7 +69,7 @@ func resourceCredentialGalaxyCreate(ctx context.Context, d *schema.ResourceData,
 		"name":            d.Get("name").(string),
 		"description":     d.Get("description").(string),
 		"organization":    d.Get("organization_id").(int),
-		"credential_type": 18, // Ansible Galaxy/Automation Hub API Token
+		"credential_type": d.Get("credential_type_id").(int), // Ansible Galaxy/Automation Hub API Token
 		"inputs": map[string]interface{}{
 			"url":      d.Get("url").(string),
 			"auth_url": d.Get("auth_url").(string),


### PR DESCRIPTION
Currently, the credential type id is static defined to 18.
however it can happen that the ids defined there are not identical across awx instances which occur an issue during the creation of the credential where the inputs schema doesn't match the credential type requirements because the id is wrong and doesn't match the credential type expected