### PR TITLE
fix(goreleaser): move to configuration v2 and remove changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,40 +1,42 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
+
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - linux
-    - freebsd
-    - darwin
-    - windows
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - linux
+      - freebsd
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
-  algorithm: sha256
+   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+   algorithm: sha256
 signs:
   - artifacts: checksum
     args:
@@ -50,5 +52,5 @@ signs:
 release:
   # If you want to manually examine the release before its live, uncomment this line:
   draft: false
-changelog:
-  skip: true
+  #changelog:
+  #  skip: true


### PR DESCRIPTION
fixing by moving to configuration v2 and remove some deprecated property
```
  • only version: 2 configuration files are supported, yours is version: 0, please update your configuration
only version: 2 configuration files are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.11.1/x64/goreleaser' failed with exit code 1
```